### PR TITLE
Add index.d.ts to support TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'swgs' {
+  export * from 'react-native-svg';
+}


### PR DESCRIPTION
Hi @msand,

I'm using `swgs` in a `react-native-web` cross-platform lib and it works great! (ios, android and web)
Since my lib is written in TypeScript the only thing I'm missing is the type declarations (I'm importing stuff directly from `swgs` like `import { Path, Svg } from 'swgs';`).

This PR adds what it seems to be the best way to support TypeScript in this case, a simple `index.d.ts` file that just exports everything from `react-native-svg`. That means it doesn't require any maintenance, as long as this lib remains a compatibility layer with the exact same API as `react-native-svg`. So when type declarations change on `react-native-svg` we don't need to do anything here, since everything is exported like this:

```ts
declare module 'swgs' {
  export * from 'react-native-svg';
}
```

I've been using this locally and it works as expected.

Let me know what you think.
Thank you for your great work.